### PR TITLE
Converted the metrics name into lower case

### DIFF
--- a/smartprom.py
+++ b/smartprom.py
@@ -146,7 +146,7 @@ def collect():
             for key, values in attrs.items():
                 # Create metric if does not exist
                 if key not in METRICS:
-                    name = key.replace('-', '_').replace(' ', '_').replace('.', '').replace('/', '_')
+                    name = key.replace('-', '_').replace(' ', '_').replace('.', '').replace('/', '_').lower()
                     desc = key.replace('_', ' ')
                     if typ == 'sat':
                         num = hex(values[0])


### PR DESCRIPTION
Some of the Gauge metrics were upper-case and some were lower-case. Converting the Gauge names to `lower()` helps in naming consistency. Having everything in lowercase also helps in filtering the queries using Prometheus.