### PR TITLE
include zero value raw metrics

### DIFF
--- a/smartprom.py
+++ b/smartprom.py
@@ -79,7 +79,7 @@ def smart_sat(dev: str) -> List[str]:
                     pass
 
                 attributes[tokens[1]] = (int(tokens[0]), int(tokens[3]))
-                if raw:
+                if raw is not None:
                     attributes[f'{tokens[1]}_raw'] = (int(tokens[0]), raw)
     return attributes
 


### PR DESCRIPTION
Right now, all raw metrics with value 0 (usually error related metrics) won't be included in the metrics because python takes 0 as false so those metrics won't be created. This PR fixes that.