### PR TITLE
Add smart_passed metric and basic information about devices

### DIFF
--- a/smartprom.py
+++ b/smartprom.py
@@ -175,7 +175,6 @@ def collect():
                 if metric not in METRICS:
                     desc = key.replace('_', ' ')
                     code = hex(values[0]) if typ == 'sat' else hex(values)
-
                     print(f'Adding new gauge {metric} ({code})')
                     METRICS[metric] = prometheus_client.Gauge(metric, f'({code}) {desc}', LABELS)
 

--- a/smartprom.py
+++ b/smartprom.py
@@ -69,7 +69,7 @@ def smart_sat(dev: str) -> tuple[dict, dict]:
     results = run_smartctl_cmd(['smartctl', '-a', '-d', 'sat', '--json=c', dev])
     results = json.loads(results)
 
-    attributes = {'smart_status_passed': get_smart_status(results)}
+    attributes = {'smart_passed': get_smart_status(results)}
     data = results['ata_smart_attributes']['table']
     for metric in data:
         code = metric['id']
@@ -105,7 +105,7 @@ def smart_nvme(dev: str) -> tuple[dict, dict]:
     results = run_smartctl_cmd(['smartctl', '-a', '-d', 'nvme', '--json=c', dev])
     results = json.loads(results)
 
-    attributes = {'smart_status_passed': get_smart_status(results)}
+    attributes = {'smart_passed': get_smart_status(results)}
     data = results['nvme_smart_health_information_log']
     for key, value in data.items():
         if key == 'temperature_sensors':
@@ -124,7 +124,7 @@ def smart_scsi(dev: str) -> tuple[dict, dict]:
     results = run_smartctl_cmd(['smartctl', '-a', '-d', 'scsi', '--json=c', dev])
     results = json.loads(results)
 
-    attributes = {'smart_status_passed': get_smart_status(results)}
+    attributes = {'smart_passed': get_smart_status(results)}
     for key, value in results.items():
         if type(value) == dict:
             for _label, _value in value.items():

--- a/smartprom.py
+++ b/smartprom.py
@@ -47,11 +47,18 @@ def get_device_info(results: dict) -> dict:
     """
     Returns a dictionary of device info
     """
-    return {
-        'model_family': results.get("model_family", "Unknown"),
-        'model_name': results.get("model_name", "Unknown"),
-        'serial_number': results.get("serial_number", "Unknown")
-    }
+    return {'model_family': results.get("model_family", "Unknown"),
+            'model_name': results.get("model_name", "Unknown"),
+            'serial_number': results.get("serial_number", "Unknown")}
+
+
+def get_smart_status(results: dict) -> int:
+    """
+    Returns a 1, 0 or -1 depends if result from
+    smart status is True, False or unknown.
+    """
+    status = results.get("smart_status")
+    return +(status.get("passed")) if status is not None else -1
 
 
 def smart_sat(dev: str) -> tuple[dict, dict]:
@@ -62,9 +69,7 @@ def smart_sat(dev: str) -> tuple[dict, dict]:
     results = run_smartctl_cmd(['smartctl', '-a', '-d', 'sat', '--json=c', dev])
     results = json.loads(results)
 
-    smart_status = results.get("smart_status")
-    attributes = {'smart_status_passed': +(smart_status.get("passed", -1))}
-
+    attributes = {'smart_status_passed': get_smart_status(results)}
     data = results['ata_smart_attributes']['table']
     for metric in data:
         code = metric['id']
@@ -100,9 +105,7 @@ def smart_nvme(dev: str) -> tuple[dict, dict]:
     results = run_smartctl_cmd(['smartctl', '-a', '-d', 'nvme', '--json=c', dev])
     results = json.loads(results)
 
-    smart_status = results.get("smart_status")
-    attributes = {'smart_status_passed': +(smart_status.get("passed", -1))}
-
+    attributes = {'smart_status_passed': get_smart_status(results)}
     data = results['nvme_smart_health_information_log']
     for key, value in data.items():
         if key == 'temperature_sensors':
@@ -121,8 +124,7 @@ def smart_scsi(dev: str) -> tuple[dict, dict]:
     results = run_smartctl_cmd(['smartctl', '-a', '-d', 'scsi', '--json=c', dev])
     results = json.loads(results)
 
-    smart_status = results.get("smart_status")
-    attributes = {'smart_status_passed': +(smart_status.get("passed", -1))}
+    attributes = {'smart_status_passed': get_smart_status(results)}
     for key, value in results.items():
         if type(value) == dict:
             for _label, _value in value.items():


### PR DESCRIPTION
This change is adding `model_family`, `model_name`, `serial_number` to metrics labels, because it makes things easier to identify devices in Grafana. I could do this by changing `-A` parameter to `-a` in smartctl command, this way I got more data. I don't think this is the best approach, but it's best I could think of right now.

I've also added new metric smartprom_smart_passed where values are `1`, `0` or `-1` when undefined.