### PR TITLE
Add support for drives connected by MegaRAID

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN apk add --no-cache smartmontools \
     && rm -rf /root/.cache/ \
     && find / -name '*.pyc' -delete
 
-COPY ./smartprom.py /smartprom.py
+COPY ./smartprom.py /megaraid.py /
 
 EXPOSE 9902
 ENTRYPOINT ["/usr/local/bin/python", "-u", "/smartprom.py"]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ _Note: You don't have to do this if you use the Docker image._
 1. Copy the `smartprom.service` file into `/etc/systemd/system` folder.
 2. Copy the `smartprom.py` file anywhere into your system.
 3. Modify `ExecStart=` in the `smartprom.service` so that it points to `smartprom.py` in your system.
-4. Run `chmod +x smartprom.py` 
+4. Run `chmod +x smartprom.py`
 5. Install `prometheus_client` for the root user, example: `sudo -H python3 -m pip install prometheus_client`
 6. Run `systemctl enable smartprom` and `systemctl start smartprom`
 7. Your metrics will now be available at `http://localhost:9902`
@@ -54,6 +54,13 @@ smartprom_power_on_hours_raw{drive="/dev/sda",model_family="Seagate BarraCuda 3.
 smartprom_airflow_temperature_cel{drive="/dev/sda",model_family="Seagate BarraCuda 3.5 (SMR)",model_name="ST6000DM003-2CY296",serial_number="WCT362XM",type="sat"} 60.0
 smartprom_airflow_temperature_cel_raw{drive="/dev/sda",model_family="Seagate BarraCuda 3.5 (SMR)",model_name="ST6000DM003-2CY296",serial_number="WCT362XM",type="sat"} 40.0
 ...
+```
+
+If you are using a MegaRAID card to connect the drives, the metrics will export look like these:
+
+```shell
+smartprom_power_on_hours_raw{drive="megaraid,0",model_family="Western Digital Ultrastar He10/12",model_name="WDC WD80EMAZ-00M9AA0",serial_number="XXXXXXXX",type="sat"} 28522.0
+smartprom_power_on_time_hours{drive="megaraid,1",model_family="Unknown",model_name="HGST HUH728080AL5200",serial_number="XXXXXXXX",type="scsi"} 37341.0
 ```
 
 ## Configuration

--- a/megaraid.py
+++ b/megaraid.py
@@ -1,0 +1,74 @@
+import json
+import re
+
+import smartprom
+
+MEGARAID_TYPE_PATTERN = r"(sat\+)?(megaraid,\d+)"
+
+
+def get_megaraid_device_info(dev: str, typ: str) -> dict:
+    """
+    Get device information connected with MegaRAID,
+    and process the information into get_device_info compatible format.
+    """
+    megaraid_id = get_megaraid_device_id(typ)
+    if megaraid_id is None:
+        return {}
+
+    results, _ = smartprom.run_smartctl_cmd(
+        ["smartctl", "-i", "--json=c", "-d", megaraid_id, dev]
+    )
+    results = json.loads(results)
+    serial_number = results.get("serial_number", "Unknown")
+    model_family = results.get("model_family", "Unknown")
+
+    # When using SAS drive and smartmontools r5286 and later,
+    # scsi_ prefix is added to model_name field.
+    # https://sourceforge.net/p/smartmontools/code/5286/
+    model_name = results.get(
+        "scsi_model_name",
+        results.get("model_name", "Unknown"),
+    )
+
+    return {
+        "model_family": model_family,
+        "model_name": model_name,
+        "serial_number": serial_number,
+    }
+
+
+def get_megaraid_device_id(typ: str) -> str | None:
+    """
+    Returns the device ID on the MegaRAID from the typ string
+    """
+    megaraid_match = re.search(MEGARAID_TYPE_PATTERN, typ)
+    if not megaraid_match:
+        return None
+
+    return megaraid_match.group(2)
+
+
+def smart_megaraid(dev: str, megaraid_id: str) -> dict:
+    """
+    Runs the smartctl command on device connected by MegaRAID
+    and processes its attributes
+    """
+    results, exit_code = smartprom.run_smartctl_cmd(
+        ["smartctl", "-A", "-H", "-d", megaraid_id, "--json=c", dev]
+    )
+    results = json.loads(results)
+
+    if results["device"]["protocol"] == "ATA":
+        # SATA device on MegaRAID
+        data = results["ata_smart_attributes"]["table"]
+        attributes = smartprom.table_to_attributes_sat(data)
+        attributes["smart_passed"] = (0, smartprom.get_smart_status(results))
+        attributes["exit_code"] = (0, exit_code)
+        return attributes
+    elif results["device"]["protocol"] == "SCSI":
+        # SAS device on MegaRAID
+        attributes = smartprom.results_to_attributes_scsi(results)
+        attributes["smart_passed"] = smartprom.get_smart_status(results)
+        attributes["exit_code"] = exit_code
+        return attributes
+    return {}

--- a/megaraid.py
+++ b/megaraid.py
@@ -37,6 +37,21 @@ def get_megaraid_device_info(dev: str, typ: str) -> dict:
     }
 
 
+def get_megaraid_device_type(dev: str, typ: str) -> str:
+    megaraid_id = get_megaraid_device_id(typ)
+    if megaraid_id is None:
+        return "unknown"
+
+    results, _ = smartprom.run_smartctl_cmd(
+        ["smartctl", "-i", "--json=c", "-d", megaraid_id, dev]
+    )
+    results = json.loads(results)
+
+    if "device" not in results or "protocol" not in results["device"]:
+        return "unknown"
+    return "sat" if results["device"]["protocol"] == "ATA" else "scsi"
+
+
 def get_megaraid_device_id(typ: str) -> str | None:
     """
     Returns the device ID on the MegaRAID from the typ string

--- a/smartprom.py
+++ b/smartprom.py
@@ -66,13 +66,10 @@ def get_drives() -> dict:
                 # After retrieving the disk information using the bus name,
                 # replace dev with a disk ID such as "megaraid,0".
                 disk_attrs = megaraid.get_megaraid_device_info(dev, device["type"])
+                disk_attrs["type"] = megaraid.get_megaraid_device_type(dev, device["type"])
                 disk_attrs["bus_device"] = dev
                 disk_attrs["megaraid_id"] = megaraid.get_megaraid_device_id(device["type"])
                 dev = disk_attrs["megaraid_id"]
-
-                # Generate device["type"] from device["protocol"]
-                # because device["type"] contains strings such as "sat+megaraid,2" or "megaraid,4".
-                disk_attrs["type"] = "sat" if device["protocol"] == "ATA" else "scsi"
             else:
                 disk_attrs = get_device_info(dev)
                 disk_attrs["type"] = device["type"]

--- a/smartprom.py
+++ b/smartprom.py
@@ -47,7 +47,13 @@ def get_drives() -> dict:
 
     # Ignore devices that fail on open, such as Virtual Drives created by MegaRAID.
     result_json["devices"] = list(
-        filter(lambda x: "open_error" not in x, result_json["devices"])
+        filter(
+            lambda x: (
+                x.get("open_error", "")
+                != "DELL or MegaRaid controller, please try adding '-d megaraid,N'"
+            ),
+            result_json["devices"],
+        )
     )
 
     if 'devices' in result_json:


### PR DESCRIPTION
For retrieving drives connected using a MegaRAID card, it is necessary to add an option such as `-d megaraid,0` to smartctl.
Also, since the MegaRAID card allows both SATA and SAS devices to be connected, it is necessary to parse the device information in the appropriate format.

Here is an example of getting SMART information for a drive I checked using this code.

* SAS drives connected by MegaRAID
```
smartprom_power_on_time_hours{drive="megaraid,4",model_family="Unknown",model_name="HGST HUH728080AL5200",serial_number="XXXXXXXX",type="scsi"} 37341.0
smartprom_power_on_time_minutes{drive="megaraid,4",model_family="Unknown",model_name="HGST HUH728080AL5200",serial_number="XXXXXXXX",type="scsi"} 34.0
```

* SATA drives connected by MegaRAID
```
smartprom_power_on_hours_raw{drive="megaraid,0",model_family="Unknown",model_name="WDC WD80EAZZ-00BKLB0",serial_number="XXXXXXXX",type="sat"} 1113.0
smartprom_power_on_hours_raw{drive="megaraid,1",model_family="Western Digital Ultrastar He10/12",model_name="WDC WD80EMAZ-00M9AA0",serial_number="XXXXXXXX",type="sat"} 28522.0
smartprom_power_on_hours_raw{drive="megaraid,2",model_family="Unknown",model_name="TOSHIBA MN08ADA800",serial_number="XXXXXXXX",type="sat"} 16522.0
```

* SATA drives connected via normal on-board interface
```
smartprom_power_on_hours_raw{drive="/dev/sde",model_family="Unknown",model_name="CSSD-S6L1TMGAX 1TB",serial_number="XXXXXXXX",type="sat"} 120.0
smartprom_power_on_hours_raw{drive="/dev/sdf",model_family="Marvell based SanDisk SSDs",model_name="SanDisk SSD PLUS 1000GB",serial_number="XXXXXXXX",type="sat"} 21203.0
```